### PR TITLE
Revisions tyler

### DIFF
--- a/constraintyacc.py
+++ b/constraintyacc.py
@@ -22,19 +22,19 @@ def p_rules(p):
 def p_rule(p):
     'rule	:	IF event THEN timedelay relationop countdelay event handles'
     p[0] = {}
-    p[0]["e1"] = p[2]
-    p[0]["e2"] = p[7]
-    p[0]["ro"] = p[5]
-    p[0]["td"] = p[4]
-    p[0]["cd"] = p[6]
-    p[0]["hd"] = p[8]
+    p[0]["body_event"] = p[2]
+    p[0]["head_event"] = p[7]
+    p[0]["comparative_keyword"] = p[5]
+    p[0]["time_delay"] = p[4]
+    p[0]["count"] = p[6]
+    p[0]["violation_handling"] = p[8]
 
 def p_event(p):
     'event	: 	ID COLON ID LPAREN vpairs RPAREN'
     p[0] = {}
-    p[0]["tag"] = p[1]
-    p[0]["name"] = p[3]
-    p[0]["vp"] = p[5]
+    p[0]["label"] = p[1]
+    p[0]["event_type_name"] = p[3]
+    p[0]["attributes"] = p[5]
 
 def p_vpairs(p):
     '''vpairs	: 	vpair COMMA vpairs
@@ -89,9 +89,9 @@ def p_handles(p):
 def p_handle(p):
     'handle	: 	CASE vtype action LPAREN labels RPAREN'
     p[0] = {}
-    p[0]["vt"] = p[2]
-    p[0]["act"] = p[3]
-    p[0]["lbs"] = p[5]
+    p[0]["violation_type"] = p[2]
+    p[0]["action"] = p[3]
+    p[0]["labels"] = p[5]
 
 def p_vtype(p):
     'vtype	: 	v1 v2'

--- a/definitionyacc.py
+++ b/definitionyacc.py
@@ -16,14 +16,15 @@ def p_rules(p):
         p[0].extend(p[3][:])
 
 def p_rule(p):
-    'rule	:	CREATE EVENTTYPE ID LPAREN ERT NUMBER gbool MAXDELAY NUMBER LPAREN vpairs RPAREN UNIQUE LPAREN labels RPAREN RPAREN'
+    'rule	:	CREATE EVENTTYPE ID LPAREN ERT NUMBER gbool NUMBER MAXDELAY NUMBER LPAREN vpairs RPAREN UNIQUE LPAREN labels RPAREN RPAREN'
     p[0] = {}
-    p[0]["ename"] = p[3]
-    p[0]["ertg"] = p[6]
-    p[0]["nsg"] = p[7]
-    p[0]["maxdelay"] = p[9]
-    p[0]["vps"] = p[11]
-    p[0]["unique"] = p[15] 
+    p[0]["event_type_name"] = p[3]
+    p[0]["event_report_time_granularity"] = p[6]
+    p[0]["event_report_time_no_skipping"] = p[7]
+    p[0]["event_report_time_no_skipping_granularity"] = p[8]
+    p[0]["max_delay_scope"] = p[10]
+    p[0]["attributes"] = p[12]
+    p[0]["unique"] = p[16] 
 
 def p_gbool(p):
     '''gbool	: 	SKIPPING NUMBER
@@ -63,7 +64,7 @@ parser = yacc.yacc()
 
 s = '''
 CREATE EVENTTYPE RentBike (
-ERT 1 NOSKIPPING
+ERT 1 NOSKIPPING 1
 MAXDELAY 5
 (Bid:str, Cid:str)
 UNIQUE (Bid, Cid, event_time))

--- a/eventgen_bike_rental.py
+++ b/eventgen_bike_rental.py
@@ -13,12 +13,12 @@ for day in range(days):
 		z1 = users * day + s
 		z2 = z1 + random.randint(1,users-s)
 		bid = bids[users*day+cid]
-		rent, ret = {"event_type_name":"rentBike", "bid":bid, "cid":cid, "event_report_time":z1}, {"event_type_name":"returnBike", "bid":bid, "cid":cid, "event_report_time":z2}
+		rent, ret = {"event_type_name":"rentBike", "bid":bid, "cid":cid, "event_time":z1}, {"event_type_name":"returnBike", "bid":bid, "cid":cid, "event_time":z2}
 		res.extend([rent, ret])
 for i in range(2*days):
 	for j in range(bikes):
-		res.append({"event_type_name":"reportLocation", "bid":j, "event_report_time":10*i})
-res.sort(key=lambda x: x["event_report_time"])
+		res.append({"event_type_name":"reportLocation", "bid":j, "event_time":10*i})
+res.sort(key=lambda x: x["event_time"])
 batchid = 0
 with open("events.txt", "a") as f:
 	batch = ""
@@ -28,8 +28,8 @@ with open("events.txt", "a") as f:
 		s = ""
 		curr = 0
 		for k,v in i.items():
-			s += f"{k}: {v}, "
-			if k=="event_report_time":
+			s += f"{k}: {v}; "
+			if k=="event_time":
 				curr = v
 		s = s[:-2]
 		batch += '{'+f"{s}"+"}\n"

--- a/eventgen_icost.py
+++ b/eventgen_icost.py
@@ -1,0 +1,24 @@
+import random
+import numpy as np
+import time
+import sys
+import string
+batch_size, fid = int(float(sys.argv[1])), sys.argv[2]
+random.seed(fid)
+t1 = time.time()
+letters = string.ascii_letters
+loc = f"./sample_events_icost/icost_events-batch_size_{batch_size}-{fid}.txt"
+for i in range(100):
+	with open(loc, "a") as f:
+		f.write(f"batch_size_{batch_size}-{fid}-{i}: {i}\n")
+		for j in range(batch_size):
+			account = str(random.randint(10e11,10e12))
+			product_code = ''.join(random.choice(letters) for i in range(9))
+			service_tag = ''.join(random.choice(letters) for i in range(9))
+			start_time = random.randint(1, 10e8) 
+			time_diff = random.randint(1, 10e8)
+			timestamp_interval = f"{time.strftime('%Y %H:%M:%S', time.gmtime(start_time))}-{time.strftime('%Y %H:%M:%S', time.gmtime(start_time+time_diff))}" 
+			icost = random.randint(-10e6, 10e6)
+			f.write('{'+f"event_type_name: item_cost; account: {account}; product_code: {product_code}; service_tag: {service_tag}; timestamp_interval: {timestamp_interval}; icost: {icost/10e5}; event_time: {i}"+"}\n")
+		f.write("END\n")
+print(f"Time taken for batch_size_{batch_size}-{fid}: {time.time() - t1}s")

--- a/eventgen_online_shopping.py
+++ b/eventgen_online_shopping.py
@@ -1,6 +1,9 @@
 import random
 import numpy as np
 import time
+import sys
+
+batch_size, conf_size = int(sys.argv[1]), sys.argv[2]
 t1 = time.time()
 # One day has 86400 seconds
 day = 86400
@@ -20,7 +23,7 @@ for uid in uids:
 	z1a = z0 + np.clip((int(xmax*(0.5+np.random.normal(0,1)))),1,xmax-1)
 	z1b = z0 + np.clip((int(xmax*(0.5+np.random.normal(0,1)))),1,xmax-1)
 	picking = {"event_type_name": "picking", 'order_id': str(oid), 'item_id': "cast iron", 'warehouse_id': str(wid), "event_time": z1a}
-	picking = {"event_type_name": "picking", 'order_id': str(oid), 'item_id': "chainmail cleaner", 'warehouse_id': str(wid), "event_time": z1b}	
+	picking = {"event_type_name": "picking", 'order_id': str(oid), 'item_id': "chainmail cleaner", 'package_id': str(pid), 'warehouse_id': str(wid), "event_time": z1b}	
 	z2 = max(z1a, z1b) + np.clip((int(ymax*(0.5+np.random.normal(0,1)))),1,ymax-1)
 	packing = {"event_type_name": "packing", 'order_id': str(oid), 'package_id': str(pid), 'item_id_quantity_mapping': default_item_id_quantity_mapping, 'warehouse_id': str(wid), "event_time": z2}
 	z3 = z2 + np.clip((int(ymax*(0.5+np.random.normal(0,1)))),1,ymax-1)
@@ -30,13 +33,16 @@ for uid in uids:
 	ship = {"event_type_name": "ship", 'package_id': str(pid), 'warehouse_id': str(wid), 'carrier_id': str(cid), 'tracking_number': str(tid), "event_time": z4+1}
 	z5 = z4 + np.clip((int(mmax*(0.5+np.random.normal(0,1)))),1,mmax-1)
 	deliver = {"event_type_name": "deliver", 'package_id': str(pid), 'carrier_id': str(cid), 'tracking_number': str(tid), "event_time": z5}
-	confirm_delivery = {"event_type_name": "confirm_delivery", 'package_id': str(pid), 'carrier_id': str(cid), 'tracking_number': str(tid), "event_time": z5+1}	
-	res.extend([place_order, picking, packing, assign_carrier, print_shipping_label, ship, deliver, confirm_delivery])
+	for j in range(int(conf_size)):
+		confirm_delivery = {"confirm_id": str(j), "event_type_name": "confirm_delivery", 'package_id': str(pid), 'carrier_id': str(cid), 'tracking_number': str(tid), "event_time": z5+1}
+		res.append(confirm_delivery)	
+	res.extend([place_order, picking, packing, assign_carrier, print_shipping_label, ship, deliver])
 
 res.sort(key=lambda x: x["event_time"])
 
-batchid, batch_size = 0, 100
-with open("online_shopping_events.txt", "a") as f:
+batchid= 0
+loc = f"./sample_events/online_shopping_events-batch_size_{batch_size}-conf_size_{conf_size}.txt"
+with open(loc, "a") as f:
 	batch = ""
 	batch_count = 0
 	for i in res:
@@ -62,11 +68,11 @@ Events:
 place_order = {'user_id': 'TEXT', 'order_id': 'TEXT', 'item_id_quantity_mapping': 'TEXT',
                                    'payment_method': 'TEXT', 'payment_amount': 'INTEGER',
                                    'payment_tracking_id': 'TEXT'}
-picking = {'order_id': 'TEXT', 'item_id': 'TEXT', 'warehouse_id': 'TEXT'}
+picking = {'order_id': 'TEXT', 'item_id': 'TEXT', 'warehouse_id': 'TEXT', 'package_id': 'TEXT'}
 packing = {'order_id': 'TEXT', 'package_id': 'TEXT', 'item_id_quantity_mapping': 'TEXT', 'warehouse_id': 'TEXT'}
 assign_carrier = {'package_id': 'TEXT', 'warehouse_id': 'TEXT', 'carrier_id': 'TEXT'}
 print_shipping_label = {'package_id': 'TEXT', 'warehouse_id': 'TEXT', 'carrier_id': 'TEXT', 'tracking_number': 'TEXT'}
 ship = {'package_id': 'TEXT', 'warehouse_id': 'TEXT', 'carrier_id': 'TEXT', 'tracking_number': 'TEXT'}
 deliver = {'package_id': 'TEXT', 'carrier_id': 'TEXT', 'tracking_number': 'TEXT'}
-confirm_delivery = {'package_id': 'TEXT', 'carrier_id': 'TEXT', 'tracking_number': 'TEXT'}
+confirm_delivery = {'confirm_id': 'TEXT', 'package_id': 'TEXT', 'carrier_id': 'TEXT', 'tracking_number': 'TEXT'}
 '''

--- a/eventgen_online_shopping.py
+++ b/eventgen_online_shopping.py
@@ -17,9 +17,11 @@ for uid in uids:
 	# Start of the event chain
 	z0 = random.randint(0,day)
 	place_order = {"event_type_name": "place_order", "user_id": str(uid), 'order_id': str(oid), 'item_id_quantity_mapping': default_item_id_quantity_mapping, 'payment_method': 'apple pay', 'payment_amount': random.randint(90,10e5)/100,'payment_tracking_id': str(pid), "event_time": z0}
-	z1 = z0 + np.clip((int(xmax*(0.5+np.random.normal(0,1)))),1,xmax-1)
-	picking = {"event_type_name": "picking", 'order_id': str(oid), 'item_id': str(iid), 'warehouse_id': str(wid), "event_time": z1}
-	z2 = z1 + np.clip((int(ymax*(0.5+np.random.normal(0,1)))),1,ymax-1)
+	z1a = z0 + np.clip((int(xmax*(0.5+np.random.normal(0,1)))),1,xmax-1)
+	z1b = z0 + np.clip((int(xmax*(0.5+np.random.normal(0,1)))),1,xmax-1)
+	picking = {"event_type_name": "picking", 'order_id': str(oid), 'item_id': "cast iron", 'warehouse_id': str(wid), "event_time": z1a}
+	picking = {"event_type_name": "picking", 'order_id': str(oid), 'item_id': "chainmail cleaner", 'warehouse_id': str(wid), "event_time": z1b}	
+	z2 = max(z1a, z1b) + np.clip((int(ymax*(0.5+np.random.normal(0,1)))),1,ymax-1)
 	packing = {"event_type_name": "packing", 'order_id': str(oid), 'package_id': str(pid), 'item_id_quantity_mapping': default_item_id_quantity_mapping, 'warehouse_id': str(wid), "event_time": z2}
 	z3 = z2 + np.clip((int(ymax*(0.5+np.random.normal(0,1)))),1,ymax-1)
 	assign_carrier = {"event_type_name": "assign_carrier", 'package_id': str(pid), 'warehouse_id': str(wid), 'carrier_id': str(cid), "event_time": z3}

--- a/eventgen_online_shopping_issac.py
+++ b/eventgen_online_shopping_issac.py
@@ -1,0 +1,69 @@
+import random
+import numpy as np
+import time
+
+conf_size = 1
+t1 = time.time()
+# One day has 86400 seconds
+day = 86400
+xmax, ymax, zmax, mmax = day, day, 7*day, 2*day 
+oid, pid, wid, cid, tid, iid = 0, 0, 0, 0, 0, 0
+uids = list(range(10000)) 
+random.shuffle(uids)
+res = []
+default_item_id_quantity_mapping = "{'cast iron': 2, 'chainmail cleaner': 1}"
+
+for uid in uids:
+	# slightly random ids
+	oid, pid, wid, cid, tid, iid = oid + random.randint(1,5), pid + random.randint(1,5), wid + random.randint(1,5), cid + random.randint(1,5), tid + random.randint(1,5), iid + random.randint(1,5) 
+	# Start of the event chain
+	z0 = random.randint(0,day)
+	place_order = {"event_type_name": "place_order", "user_id": str(uid), 'order_id': str(oid), 'item_id_quantity_mapping': default_item_id_quantity_mapping, 'payment_method': 'apple pay', 'payment_amount': random.randint(90,10e5)/100,'payment_tracking_id': str(pid), "event_time": z0}
+	z1a = z0 + np.clip((int(xmax*(0.5+np.random.normal(0,1)))),1,xmax-1)
+	z1b = z0 + np.clip((int(xmax*(0.5+np.random.normal(0,1)))),1,xmax-1)
+	picking = {"event_type_name": "picking", 'order_id': str(oid), 'item_id': "cast iron", 'warehouse_id': str(wid), "event_time": z1a}
+	picking = {"event_type_name": "picking", 'order_id': str(oid), 'item_id': "chainmail cleaner", 'package_id': str(pid), 'warehouse_id': str(wid), "event_time": z1b}	
+	z2 = max(z1a, z1b) + np.clip((int(ymax*(0.5+np.random.normal(0,1)))),1,ymax-1)
+	packing = {"event_type_name": "packing", 'order_id': str(oid), 'package_id': str(pid), 'item_id_quantity_mapping': default_item_id_quantity_mapping, 'warehouse_id': str(wid), "event_time": z2}
+	z3 = z2 + np.clip((int(ymax*(0.5+np.random.normal(0,1)))),1,ymax-1)
+	assign_carrier = {"event_type_name": "assign_carrier", 'package_id': str(pid), 'warehouse_id': str(wid), 'carrier_id': str(cid), "event_time": z3}
+	z4 = z3 + np.clip((int(zmax*(0.5+np.random.normal(0,1)))),1,zmax-1)
+	print_shipping_label = {"event_type_name": "print_shipping_label", 'package_id': str(pid), 'warehouse_id': str(wid), 'carrier_id': str(cid), 'tracking_number': str(tid), "event_time": z4}
+	ship = {"event_type_name": "ship", 'package_id': str(pid), 'warehouse_id': str(wid), 'carrier_id': str(cid), 'tracking_number': str(tid), "event_time": z4+1}
+	z5 = z4 + np.clip((int(mmax*(0.5+np.random.normal(0,1)))),1,mmax-1)
+	deliver = {"event_type_name": "deliver", 'package_id': str(pid), 'carrier_id': str(cid), 'tracking_number': str(tid), "event_time": z5}
+	for j in range(int(conf_size)):
+		confirm_delivery = {"confirm_id": str(j), "event_type_name": "confirm_delivery", 'package_id': str(pid), 'carrier_id': str(cid), 'tracking_number': str(tid), "event_time": z5+1}
+		res.append(confirm_delivery)	
+	res.extend([place_order, picking, packing, assign_carrier, print_shipping_label, ship, deliver])
+
+res.sort(key=lambda x: x["event_time"])
+
+loc = f"./online_shopping_events_issac-batch_size_conf_size_{conf_size}.txt"
+with open(loc, "a") as f:
+	for i in res:
+		s = ""
+		curr = 0
+		for k,v in i.items():
+			s += f"{k}={v}; "
+			if k=="event_time":
+				curr = v
+		s = s[:-2]
+		f.write(f"{curr} 1 1 {s}")
+
+#print(*res, sep='\n')
+print(f"Time taken: {time.time() - t1}s")
+
+'''
+Events:
+place_order = {'user_id': 'TEXT', 'order_id': 'TEXT', 'item_id_quantity_mapping': 'TEXT',
+                                   'payment_method': 'TEXT', 'payment_amount': 'INTEGER',
+                                   'payment_tracking_id': 'TEXT'}
+picking = {'order_id': 'TEXT', 'item_id': 'TEXT', 'warehouse_id': 'TEXT', 'package_id': 'TEXT'}
+packing = {'order_id': 'TEXT', 'package_id': 'TEXT', 'item_id_quantity_mapping': 'TEXT', 'warehouse_id': 'TEXT'}
+assign_carrier = {'package_id': 'TEXT', 'warehouse_id': 'TEXT', 'carrier_id': 'TEXT'}
+print_shipping_label = {'package_id': 'TEXT', 'warehouse_id': 'TEXT', 'carrier_id': 'TEXT', 'tracking_number': 'TEXT'}
+ship = {'package_id': 'TEXT', 'warehouse_id': 'TEXT', 'carrier_id': 'TEXT', 'tracking_number': 'TEXT'}
+deliver = {'package_id': 'TEXT', 'carrier_id': 'TEXT', 'tracking_number': 'TEXT'}
+confirm_delivery = {'confirm_id': 'TEXT', 'package_id': 'TEXT', 'carrier_id': 'TEXT', 'tracking_number': 'TEXT'}
+'''

--- a/eventgen_online_shopping_no_skipping.py
+++ b/eventgen_online_shopping_no_skipping.py
@@ -1,0 +1,98 @@
+import random
+import numpy as np
+import time
+import sys
+
+def gen_next(curr_event, id_chain):
+	event_type = curr_event["event_type_name"]
+#	if (event_type != "place_order"): print(event_type)
+	z = curr_event["event_time"]
+	next_event = {}
+	if event_type == "place_order":
+		next_event = {"event_type_name": "picking", 'order_id': curr_event["order_id"], 'item_id': "cast iron", 'warehouse_id': id_chain["warehouse_id"], "package_id": id_chain["package_id"], "event_time": z + np.clip((int(xmax*(0.5+np.random.normal(0,1)))),1,xmax-1)}
+		id_chain["warehouse_id"] += random.randint(1,5)
+		id_chain["package_id"] += random.randint(1,5)
+	elif event_type == "picking":
+		next_event = {"event_type_name": "packing", 'order_id': curr_event["order_id"], 'package_id': curr_event["package_id"], 'item_id_quantity_mapping': default_item_id_quantity_mapping, 'warehouse_id': curr_event["warehouse_id"], "event_time": z + np.clip((int(ymax*(0.5+np.random.normal(0,1)))),1,ymax-1)}
+	elif event_type == "packing":
+		next_event = {"event_type_name": "assign_carrier", 'package_id': curr_event["package_id"], 'warehouse_id': curr_event["warehouse_id"], 'carrier_id': id_chain["carrier_id"], "event_time": z + np.clip((int(ymax*(0.5+np.random.normal(0,1)))),1,ymax-1)}
+		id_chain["carrier_id"] += random.randint(1,5)
+	elif event_type == "assign_carrier":
+		next_event = {"event_type_name": "print_shipping_label", 'package_id': curr_event["package_id"], 'warehouse_id': curr_event["warehouse_id"], 'carrier_id': curr_event["carrier_id"], 'tracking_number': id_chain["tracking_number"], "event_time": z + np.clip((int(zmax*(0.5+np.random.normal(0,1)))),1,zmax-1)} 
+		id_chain["tracking_number"] += random.randint(1,5)
+	elif event_type == "print_shipping_label":
+		next_event = {"event_type_name": "ship", 'package_id': curr_event["package_id"], 'warehouse_id': curr_event["warehouse_id"], 'carrier_id': curr_event["carrier_id"], 'tracking_number': curr_event["tracking_number"], "event_time": z+1}
+	elif event_type == "ship":
+		next_event = {"event_type_name": "deliver", 'package_id': curr_event["package_id"], 'carrier_id': curr_event["carrier_id"], 'tracking_number': curr_event["tracking_number"], "event_time": z + np.clip((int(mmax*(0.5+np.random.normal(0,1)))),1,mmax-1)}
+	elif event_type == "confirm_delivery":
+		next_event = {"confirm_id": str(j), "event_type_name": "confirm_delivery", 'package_id': curr_event["package_id"], 'carrier_id': curr_event["carrier_id"], 'tracking_number': curr_event["tracking_number"], "event_time": z+1}
+	else:
+		print(f"Error: {event_type} is not a continuing event for this workflow")
+	return next_event
+
+if __name__ == '__main__':
+	batch_size, fid = int(sys.argv[1]), sys.argv[2]
+	random.seed(fid)
+	t1 = time.time()
+	# One day has 86400 seconds
+	day = 86400
+	xmax, ymax, zmax, mmax = 10, 10, 70, 20
+	id_chain = {"order_id": 0, "package_id": 0, "warehouse_id": 0, "carrier_id": 0, "tracking_number": 0} 
+	res = [[] for y in range(100)]
+	default_item_id_quantity_mapping = "{'cast iron': 2}"
+	#Init for timestamp 0
+	for i in range(batch_size):
+		place_order = {"event_type_name": "place_order", "user_id": str(i), 'order_id': str(id_chain["order_id"]), 'item_id_quantity_mapping': default_item_id_quantity_mapping, 'payment_method': 'apple pay', 'payment_amount': random.randint(90,10e5)/100,'payment_tracking_id': str(id_chain["package_id"]), "event_time": 0}
+		res[0].append(place_order)
+		next_event = gen_next(place_order, id_chain)
+		id_chain["order_id"] += random.randint(1,5)		
+
+	for z in range(100):
+		for curr_event in res[z]:
+			if curr_event["event_type_name"] == "deliver":
+				continue
+			next_event = gen_next(curr_event, id_chain)
+			id_chain["order_id"] += random.randint(1,5)
+			next_z = next_event["event_time"]
+			if next_z < 100:
+				if len(res[next_z]) < batch_size: 
+					res[next_z].append(next_event)
+		#If not full fill rest with place_order
+		if len(res[z]) < batch_size:
+			for i in range(batch_size-len(res[z])):
+				place_order = {"event_type_name": "place_order", "user_id": str(i), 'order_id': str(id_chain["order_id"]), 'item_id_quantity_mapping': default_item_id_quantity_mapping, 'payment_method': 'apple pay', 'payment_amount': random.randint(90,10e5)/100,'payment_tracking_id': str(id_chain["package_id"]), "event_time": z}
+				id_chain["order_id"] += random.randint(1,5)	
+				res[z].append(place_order)
+
+
+loc = f"./sample_events_no_skipping/online_shopping_events-batch_size_{batch_size}-{fid}.txt"
+with open(loc, "a") as f:
+	batch = ""
+	for i in range(100):
+		for currd in res[i]:
+			s = "{"	
+			for k,v in currd.items():
+				s += f"{k}: {v}; "
+			s = s[:-2]
+			s += "}"
+			batch += f"{s}"+"\n"
+		f.write(f"batch_size_{batch_size}-{fid}-{i}: {i}\n{batch}END\n")
+		batch = ""
+
+#sanity check for fixed batch_size
+#size_arr = [len(x) for x in res]
+#print(size_arr)
+print(f"Time taken for batch_size_{batch_size}-{fid}: {time.time() - t1}s")
+'''
+Events:
+place_order = {'user_id': 'TEXT', 'order_id': 'TEXT', 'item_id_quantity_mapping': 'TEXT',
+                                   'payment_method': 'TEXT', 'payment_amount': 'INTEGER',
+                                   'payment_tracking_id': 'TEXT'}
+picking = {'order_id': 'TEXT', 'item_id': 'TEXT', 'warehouse_id': 'TEXT', 'package_id': 'TEXT'}
+packing = {'order_id': 'TEXT', 'package_id': 'TEXT', 'item_id_quantity_mapping': 'TEXT', 'warehouse_id': 'TEXT'}
+assign_carrier = {'package_id': 'TEXT', 'warehouse_id': 'TEXT', 'carrier_id': 'TEXT'}
+print_shipping_label = {'package_id': 'TEXT', 'warehouse_id': 'TEXT', 'carrier_id': 'TEXT', 'tracking_number': 'TEXT'}
+ship = {'package_id': 'TEXT', 'warehouse_id': 'TEXT', 'carrier_id': 'TEXT', 'tracking_number': 'TEXT'}
+deliver = {'package_id': 'TEXT', 'carrier_id': 'TEXT', 'tracking_number': 'TEXT'}
+confirm_delivery = {'confirm_id': 'TEXT', 'package_id': 'TEXT', 'carrier_id': 'TEXT', 'tracking_number': 'TEXT'}
+'''

--- a/eventgen_online_shopping_no_skipping_issac.py
+++ b/eventgen_online_shopping_no_skipping_issac.py
@@ -1,0 +1,112 @@
+import random
+import numpy as np
+import time
+import sys
+
+def getenactmentid(event, okey, pkey):
+	eventtype = event["eventtypename"]
+	if eventtype in ["placeorder", "picking", "packing"]:
+		return okey[event["orderid"]]
+	return pkey[event["packageid"]]
+
+def gennext(currevent, idchain, okey, pkey):
+	eventtype = currevent["eventtypename"]
+#	if (eventtype != "placeorder"): print(eventtype)
+	z = currevent["eventtime"]
+	nextevent = {}
+	if eventtype == "placeorder":
+		nextevent = {"eventtypename": "picking", 'orderid': currevent["orderid"], 'itemid': "castiron", 'warehouseid': idchain["warehouseid"], "packageid": idchain["packageid"], "eventtime": z + np.clip((int(xmax*(0.5+np.random.normal(0,1)))),1,xmax-1)}
+		idchain["warehouseid"] += random.randint(1,5)
+		idchain["packageid"] += random.randint(1,5)
+	elif eventtype == "picking":
+		nextevent = {"eventtypename": "packing", 'orderid': currevent["orderid"], 'packageid': currevent["packageid"], 'itemidquantitymapping': defaultitemidquantitymapping, 'warehouseid': currevent["warehouseid"], "eventtime": z + np.clip((int(ymax*(0.5+np.random.normal(0,1)))),1,ymax-1)}
+	elif eventtype == "packing":
+		pkey[currevent["packageid"]] = okey[currevent["orderid"]]
+		nextevent = {"eventtypename": "assigncarrier", 'packageid': currevent["packageid"], 'warehouseid': currevent["warehouseid"], 'carrierid': idchain["carrierid"], "eventtime": z + np.clip((int(ymax*(0.5+np.random.normal(0,1)))),1,ymax-1)}
+		idchain["carrierid"] += random.randint(1,5)
+	elif eventtype == "assigncarrier":
+		nextevent = {"eventtypename": "printshippinglabel", 'packageid': currevent["packageid"], 'warehouseid': currevent["warehouseid"], 'carrierid': currevent["carrierid"], 'trackingnumber': idchain["trackingnumber"], "eventtime": z + np.clip((int(zmax*(0.5+np.random.normal(0,1)))),1,zmax-1)} 
+		idchain["trackingnumber"] += random.randint(1,5)
+	elif eventtype == "printshippinglabel":
+		nextevent = {"eventtypename": "ship", 'packageid': currevent["packageid"], 'warehouseid': currevent["warehouseid"], 'carrierid': currevent["carrierid"], 'trackingnumber': currevent["trackingnumber"], "eventtime": z+1}
+	elif eventtype == "ship":
+		nextevent = {"eventtypename": "deliver", 'packageid': currevent["packageid"], 'carrierid': currevent["carrierid"], 'trackingnumber': currevent["trackingnumber"], "eventtime": z + np.clip((int(mmax*(0.5+np.random.normal(0,1)))),1,mmax-1)}
+	elif eventtype == "confirmdelivery":
+		nextevent = {"confirmid": str(j), "eventtypename": "confirmdelivery", 'packageid': currevent["packageid"], 'carrierid': currevent["carrierid"], 'trackingnumber': currevent["trackingnumber"], "eventtime": z+1}
+	else:
+		print(f"Error: {eventtype} is not a continuing event for this workflow")
+	return nextevent
+
+if __name__ == '__main__':
+	if len(sys.argv) >= 3:
+		batchsize, fid = int(sys.argv[1]), sys.argv[2]
+	else:
+		batchsize, fid = 100, 1
+	random.seed(fid)
+	t1 = time.time()
+	# One day has 86400 seconds
+	day = 86400
+	xmax, ymax, zmax, mmax = 5, 5, 30, 10
+	idchain = {"orderid": 0, "packageid": 0, "warehouseid": 0, "carrierid": 0, "trackingnumber": 0} 
+	res = [[] for y in range(100)]
+	defaultitemidquantitymapping = "{'castiron':2}"
+	enactmentid = 0
+	okey, pkey = {}, {}
+	nametoid = {"placeorder": 2, "picking": 3, "packing": 4, "assigncarrier": 5, "printshippinglabel": 6, "ship": 7, "deliver": 8, "confirmdelivery": 9}
+
+	for z in range(1,100):		
+		#If not full fill rest with placeorder
+		if len(res[z]) < batchsize:
+			for i in range(batchsize-len(res[z])):
+				placeorder = {"eventtypename": "placeorder", "userid": str(i), 'orderid': str(idchain["orderid"]), 'itemidquantitymapping': defaultitemidquantitymapping, 'paymentmethod': 'applepay', 'paymentamount': random.randint(90,10e5)/100,'paymenttrackingid': str(idchain["packageid"]), "eventtime": z}
+				okey[str(idchain["orderid"])] = enactmentid
+				idchain["orderid"] += random.randint(1,5)
+				res[z].append(placeorder)
+				enactmentid += 1
+		for currevent in res[z]:
+			if currevent["eventtypename"] == "deliver":
+				continue
+			nextevent = gennext(currevent, idchain, okey, pkey)
+			idchain["orderid"] += random.randint(1,5)
+			nextz = nextevent["eventtime"]
+			if nextz < 100:
+				if len(res[nextz]) < batchsize: 
+					res[nextz].append(nextevent)
+
+loc = f"./sample_events_no_skipping_issac/online_shopping_events-batchsize_{batchsize}-{fid}.txt"
+with open(loc, "a") as f:
+	for i in range(1,100):
+		out, nout = "", ""
+		for currd in res[i]:
+			s = f"{i} {getenactmentid(currd, okey, pkey)} {nametoid[currd['eventtypename']]} "	
+			for k,v in currd.items():
+				if k == "eventtypename":
+					s += f"{v}"
+				else:
+					s += f" {k}={v}"
+			s += '\n'
+			if (currd["eventtypename"] == "placeorder"):
+				out += f"{i-1} {getenactmentid(currd, okey, pkey)} 1 START\n"
+			nout += s
+			if (currd["eventtypename"] == "deliver") and i != 99:
+				out += f"{i+1} {getenactmentid(currd, okey, pkey)} 10 END\n"
+		f.write(out)
+		f.write(nout)
+
+#sanity check for fixed batchsize
+#sizearr = [len(x) for x in res]
+#print(sizearr)
+print(f"Time taken for batchsize{batchsize}-{fid}: {time.time() - t1}s")
+'''
+Events:
+placeorder = {'userid': 'TEXT', 'orderid': 'TEXT', 'itemidquantitymapping': 'TEXT',
+                                   'paymentmethod': 'TEXT', 'paymentamount': 'INTEGER',
+                                   'paymenttrackingid': 'TEXT'}
+picking = {'orderid': 'TEXT', 'itemid': 'TEXT', 'warehouseid': 'TEXT', 'packageid': 'TEXT'}
+packing = {'orderid': 'TEXT', 'packageid': 'TEXT', 'itemidquantitymapping': 'TEXT', 'warehouseid': 'TEXT'}
+assigncarrier = {'packageid': 'TEXT', 'warehouseid': 'TEXT', 'carrierid': 'TEXT'}
+printshippinglabel = {'packageid': 'TEXT', 'warehouseid': 'TEXT', 'carrierid': 'TEXT', 'trackingnumber': 'TEXT'}
+ship = {'packageid': 'TEXT', 'warehouseid': 'TEXT', 'carrierid': 'TEXT', 'trackingnumber': 'TEXT'}
+deliver = {'packageid': 'TEXT', 'carrierid': 'TEXT', 'trackingnumber': 'TEXT'}
+confirmdelivery = {'confirmid': 'TEXT', 'packageid': 'TEXT', 'carrierid': 'TEXT', 'trackingnumber': 'TEXT'}
+'''

--- a/eventgen_online_shopping_no_skipping_issac_count_enactments.py
+++ b/eventgen_online_shopping_no_skipping_issac_count_enactments.py
@@ -1,0 +1,119 @@
+import random
+import numpy as np
+import time
+import sys
+
+def getenactmentid(event, okey, pkey):
+	eventtype = event["eventtypename"]
+	if eventtype in ["placeorder", "picking", "packing"]:
+		return okey[event["orderid"]]
+	return pkey[event["packageid"]]
+
+def gennext(currevent, idchain, okey, pkey, enactmentid):
+	eventtype = currevent["eventtypename"]
+#	if (eventtype != "placeorder"): print(eventtype)
+	z = currevent["eventtime"]
+	nextevent = {}
+	if eventtype == "start":
+		nextevent = {"eventtypename": "placeorder", "userid": str(random.randint(1,1000)), 'orderid': str(idchain["orderid"]), 'itemidquantitymapping': defaultitemidquantitymapping, 'paymentmethod': 'applepay', 'paymentamount': random.randint(90,10e5)/100,'paymenttrackingid': str(idchain["packageid"]), "eventtime": z+1}
+		okey[str(idchain["orderid"])] = currevent["enactmentid"]
+		idchain["orderid"] += random.randint(1,5)
+	elif eventtype == "placeorder":
+		nextevent = {"eventtypename": "picking", 'orderid': currevent["orderid"], 'itemid': "castiron", 'warehouseid': idchain["warehouseid"], "packageid": idchain["packageid"], "eventtime": z + np.clip((int(xmax*(0.5+np.random.normal(0,1)))),1,xmax-1)}
+		idchain["warehouseid"] += random.randint(1,5)
+		idchain["packageid"] += random.randint(1,5)
+	elif eventtype == "picking":
+		nextevent = {"eventtypename": "packing", 'orderid': currevent["orderid"], 'packageid': currevent["packageid"], 'itemidquantitymapping': defaultitemidquantitymapping, 'warehouseid': currevent["warehouseid"], "eventtime": z + np.clip((int(ymax*(0.5+np.random.normal(0,1)))),1,ymax-1)}
+	elif eventtype == "packing":
+		pkey[currevent["packageid"]] = okey[currevent["orderid"]]
+		nextevent = {"eventtypename": "assigncarrier", 'packageid': currevent["packageid"], 'warehouseid': currevent["warehouseid"], 'carrierid': idchain["carrierid"], "eventtime": z + np.clip((int(ymax*(0.5+np.random.normal(0,1)))),1,ymax-1)}
+		idchain["carrierid"] += random.randint(1,5)
+	elif eventtype == "assigncarrier":
+		nextevent = {"eventtypename": "printshippinglabel", 'packageid': currevent["packageid"], 'warehouseid': currevent["warehouseid"], 'carrierid': currevent["carrierid"], 'trackingnumber': idchain["trackingnumber"], "eventtime": z + np.clip((int(zmax*(0.5+np.random.normal(0,1)))),1,zmax-1)} 
+		idchain["trackingnumber"] += random.randint(1,5)
+	elif eventtype == "printshippinglabel":
+		nextevent = {"eventtypename": "ship", 'packageid': currevent["packageid"], 'warehouseid': currevent["warehouseid"], 'carrierid': currevent["carrierid"], 'trackingnumber': currevent["trackingnumber"], "eventtime": z+1}
+	elif eventtype == "ship":
+		nextevent = {"eventtypename": "deliver", 'packageid': currevent["packageid"], 'carrierid': currevent["carrierid"], 'trackingnumber': currevent["trackingnumber"], "eventtime": z + np.clip((int(mmax*(0.5+np.random.normal(0,1)))),1,mmax-1)}
+	elif eventtype == "deliver":
+		nextevent = {"confirmid": 'c'+str(currevent["packageid"]), "eventtypename": "confirmdelivery", 'packageid': currevent["packageid"], 'carrierid': currevent["carrierid"], 'trackingnumber': currevent["trackingnumber"], "eventtime": z+1}
+	elif eventtype == "confirmdelivery":
+		nextevent = {"eventtypename": "end", "enactmentid": getenactmentid(currevent, okey, pkey), "eventtime": z+1}
+	else:
+		print(f"Error: {eventtype} is not a continuing event for this workflow")
+	return nextevent
+
+if __name__ == '__main__':
+	if len(sys.argv) >= 3:
+		batchsize, fid = int(sys.argv[1]), sys.argv[2]
+	else:
+		batchsize, fid = 100, 1
+	random.seed(fid)
+	t1 = time.time()
+	# One day has 86400 seconds
+	day = 86400
+	xmax, ymax, zmax, mmax = 5, 5, 30, 10
+	idchain = {"orderid": 0, "packageid": 0, "warehouseid": 0, "carrierid": 0, "trackingnumber": 0} 
+	res = [[] for y in range(100)]
+	defaultitemidquantitymapping = "{'castiron':2}"
+	enactmentid = 0
+	okey, pkey = {}, {}
+	nametoid = {"placeorder": 2, "picking": 3, "packing": 4, "assigncarrier": 5, "printshippinglabel": 6, "ship": 7, "deliver": 8, "confirmdelivery": 9}
+
+	for z in range(100):		
+		#If not full fill rest with placeorder
+		if len(res[z]) < batchsize:
+			for i in range(batchsize-len(res[z])):
+				start = {"eventtypename": "start", "enactmentid": enactmentid, "eventtime": z}
+				res[z].append(start)
+				enactmentid += 1
+		for currevent in res[z]:
+			if currevent["eventtypename"] == "end":
+				continue
+			nextevent = gennext(currevent, idchain, okey, pkey, enactmentid)
+			idchain["orderid"] += random.randint(1,5)
+			nextz = nextevent["eventtime"]
+			if nextz < 100:
+				if len(res[nextz]) < batchsize: 
+					res[nextz].append(nextevent)
+
+loc = f"./sample_events_no_skipping_issac/online_shopping_events-batchsize_{batchsize}-{fid}.txt"
+with open(loc, "a") as f:
+	for i in range(100):
+		s = ""
+		for currd in res[i]:
+			isenact = 0
+			if currd["eventtypename"] == "start":
+				s = f"{i} {currd['enactmentid']} 1 START"
+				isenact = 1
+			elif currd["eventtypename"] == "end":
+				s = f"{i} {currd['enactmentid']} 10 END"
+				isenact = 1
+			else:
+				s = f"{i} {getenactmentid(currd, okey, pkey)} {nametoid[currd['eventtypename']]} "
+			if isenact == 0:	
+				for k,v in currd.items():
+					if k == "eventtypename":
+						s += f"{v}"
+					else:
+						s += f" {k}={v}"
+			s += '\n'	
+			f.write(s)
+
+#sanity check for fixed batchsize
+#sizearr = [len(x) for x in res]
+#print(sizearr[0])
+print(f"Time taken for batchsize{batchsize}-{fid}: {time.time() - t1}s")
+'''
+Events:
+placeorder = {'userid': 'TEXT', 'orderid': 'TEXT', 'itemidquantitymapping': 'TEXT',
+                                   'paymentmethod': 'TEXT', 'paymentamount': 'INTEGER',
+                                   'paymenttrackingid': 'TEXT'}
+picking = {'orderid': 'TEXT', 'itemid': 'TEXT', 'warehouseid': 'TEXT', 'packageid': 'TEXT'}
+packing = {'orderid': 'TEXT', 'packageid': 'TEXT', 'itemidquantitymapping': 'TEXT', 'warehouseid': 'TEXT'}
+assigncarrier = {'packageid': 'TEXT', 'warehouseid': 'TEXT', 'carrierid': 'TEXT'}
+printshippinglabel = {'packageid': 'TEXT', 'warehouseid': 'TEXT', 'carrierid': 'TEXT', 'trackingnumber': 'TEXT'}
+ship = {'packageid': 'TEXT', 'warehouseid': 'TEXT', 'carrierid': 'TEXT', 'trackingnumber': 'TEXT'}
+deliver = {'packageid': 'TEXT', 'carrierid': 'TEXT', 'trackingnumber': 'TEXT'}
+confirmdelivery = {'confirmid': 'TEXT', 'packageid': 'TEXT', 'carrierid': 'TEXT', 'trackingnumber': 'TEXT'}
+'''

--- a/eventgen_online_shopping_no_skipping_issac_count_enactments_slow_start.py
+++ b/eventgen_online_shopping_no_skipping_issac_count_enactments_slow_start.py
@@ -1,0 +1,139 @@
+import random
+import numpy as np
+import time
+import sys
+import json
+import collections
+def getenactmentid(event, okey, pkey):
+	eventtype = event["eventtypename"]
+	if eventtype in ["placeorder", "picking", "packing"]:
+		return okey[event["orderid"]]
+	return pkey[event["packageid"]]
+
+def gennext(currevent, idchain, okey, pkey, enactmentid):
+	eventtype = currevent["eventtypename"]
+#	if (eventtype != "placeorder"): print(eventtype)
+	z = currevent["eventtime"]
+	nextevent = {}
+	if eventtype == "start":
+		nextevent = {"eventtypename": "placeorder", "userid": str(random.randint(1,1000)), 'orderid': str(idchain["orderid"]), 'itemidquantitymapping': defaultitemidquantitymapping, 'paymentmethod': 'applepay', 'paymentamount': random.randint(90,10e5)/batches,'paymenttrackingid': str(idchain["packageid"]), "eventtime": z+1}
+		okey[str(idchain["orderid"])] = currevent["enactmentid"]
+		idchain["orderid"] += random.randint(1,5)
+	elif eventtype == "placeorder":
+		nextevent = {"eventtypename": "picking", 'orderid': currevent["orderid"], 'itemid': "castiron", 'warehouseid': idchain["warehouseid"], "packageid": idchain["packageid"], "eventtime": z + np.clip((int(xmax*(0.5+np.random.normal(0,1)))),1,xmax-1)}
+		idchain["warehouseid"] += random.randint(1,5)
+		idchain["packageid"] += random.randint(1,5)
+	elif eventtype == "picking":
+		nextevent = {"eventtypename": "packing", 'orderid': currevent["orderid"], 'packageid': currevent["packageid"], 'itemidquantitymapping': defaultitemidquantitymapping, 'warehouseid': currevent["warehouseid"], "eventtime": z + np.clip((int(ymax*(0.5+np.random.normal(0,1)))),1,ymax-1)}
+	elif eventtype == "packing":
+		pkey[currevent["packageid"]] = okey[currevent["orderid"]]
+		nextevent = {"eventtypename": "assigncarrier", 'packageid': currevent["packageid"], 'warehouseid': currevent["warehouseid"], 'carrierid': idchain["carrierid"], "eventtime": z + np.clip((int(ymax*(0.5+np.random.normal(0,1)))),1,ymax-1)}
+		idchain["carrierid"] += random.randint(1,5)
+	elif eventtype == "assigncarrier":
+		nextevent = {"eventtypename": "printshippinglabel", 'packageid': currevent["packageid"], 'warehouseid': currevent["warehouseid"], 'carrierid': currevent["carrierid"], 'trackingnumber': idchain["trackingnumber"], "eventtime": z + np.clip((int(zmax*(0.5+np.random.normal(0,1)))),1,zmax-1)} 
+		idchain["trackingnumber"] += random.randint(1,5)
+	elif eventtype == "printshippinglabel":
+		nextevent = {"eventtypename": "ship", 'packageid': currevent["packageid"], 'warehouseid': currevent["warehouseid"], 'carrierid': currevent["carrierid"], 'trackingnumber': currevent["trackingnumber"], "eventtime": z+1}
+	elif eventtype == "ship":
+		nextevent = {"eventtypename": "deliver", 'packageid': currevent["packageid"], 'carrierid': currevent["carrierid"], 'trackingnumber': currevent["trackingnumber"], "eventtime": z + np.clip((int(mmax*(0.5+np.random.normal(0,1)))),1,mmax-1)}
+	elif eventtype == "deliver":
+		nextevent = {"confirmid": 'c'+str(currevent["packageid"]), "eventtypename": "confirmdelivery", 'packageid': currevent["packageid"], 'carrierid': currevent["carrierid"], 'trackingnumber': currevent["trackingnumber"], "eventtime": z+1}
+	elif eventtype == "confirmdelivery":
+		nextevent = {"eventtypename": "end", "enactmentid": getenactmentid(currevent, okey, pkey), "eventtime": z+1}
+	else:
+		print(f"Error: {eventtype} is not a continuing event for this workflow")
+	return nextevent
+
+if __name__ == '__main__':
+	if len(sys.argv) >= 3:
+		batchsize, fid = int(sys.argv[1]), sys.argv[2]
+	else:
+		batchsize, fid = 100, 1
+	random.seed(fid)
+	batches = 1000
+	t1 = time.time()
+	# One day has 86400 seconds
+	slow_start_batches, slow_start_ratio = 8, 0.125
+	day = 86400
+	xmax, ymax, zmax, mmax = 5, 5, 30, 10
+	idchain = {"orderid": 0, "packageid": 0, "warehouseid": 0, "carrierid": 0, "trackingnumber": 0} 
+	res = [[] for y in range(batches)]
+	defaultitemidquantitymapping = "{'castiron':2}"
+	enactmentid = 0
+	okey, pkey = {}, {}
+	nametoid = {"placeorder": 2, "picking": 3, "packing": 4, "assigncarrier": 5, "printshippinglabel": 6, "ship": 7, "deliver": 8, "confirmdelivery": 9}
+
+	for z in range(batches):		
+		#If not full fill rest with placeorder
+		curr_batchsize = batchsize
+		if z < slow_start_batches:
+			curr_batchsize *= slow_start_ratio
+		if len(res[z]) < batchsize:
+			factor = batchsize-len(res[z])
+			if z < slow_start_batches:
+				factor = min(curr_batchsize, factor)
+			factor = int(factor)
+			for i in range(factor):
+				start = {"eventtypename": "start", "enactmentid": enactmentid, "eventtime": z}
+				res[z].append(start)
+				enactmentid += 1
+		for currevent in res[z]:
+			if currevent["eventtypename"] == "end":
+				continue
+			nextevent = gennext(currevent, idchain, okey, pkey, enactmentid)
+			idchain["orderid"] += random.randint(1,5)
+			nextz = nextevent["eventtime"]
+			if nextz < batches:
+				if len(res[nextz]) < batchsize: 
+					res[nextz].append(nextevent)
+
+loc = f"./sample_events_no_skipping_issac/online_shopping_events-batchsize_{batchsize}-batches_{batches}-{fid}.txt"
+with open(loc, "a") as f:
+	for i in range(batches):
+		s = ""
+		for currd in res[i]:
+			isenact = 0
+			if currd["eventtypename"] == "start":
+				s = f"{i} {currd['enactmentid']} 1 START"
+				isenact = 1
+			elif currd["eventtypename"] == "end":
+				s = f"{i} {currd['enactmentid']} 10 END"
+				isenact = 1
+			else:
+				s = f"{i} {getenactmentid(currd, okey, pkey)} {nametoid[currd['eventtypename']]} "
+			if isenact == 0:	
+				for k,v in currd.items():
+					if k == "eventtypename":
+						s += f"{v}"
+					else:
+						s += f" {k}={v}"
+			s += '\n'	
+			f.write(s)
+
+#sanity check for fixed batchsize
+#sizearr = [len(x) for x in res]
+#print(sizearr[0])
+#see event ratio within each batch
+sanitized_res = [[y["eventtypename"] for y in x] for x in res]
+freqs = []
+for sr in sanitized_res:
+	freqs.append(collections.Counter(sr))
+ratio_loc = f"./ratios/online_shopping_events-batch_size_{batchsize}-batches_{batches}-{fid}_ratios.txt"
+for freq in freqs:
+	with open(ratio_loc, "a") as f:
+		f.write(json.dumps(freq))
+		f.write('\n')
+print(f"Time taken for batchsize{batchsize}-{fid}: {time.time() - t1}s")
+'''
+Events:
+placeorder = {'userid': 'TEXT', 'orderid': 'TEXT', 'itemidquantitymapping': 'TEXT',
+                                   'paymentmethod': 'TEXT', 'paymentamount': 'INTEGER',
+                                   'paymenttrackingid': 'TEXT'}
+picking = {'orderid': 'TEXT', 'itemid': 'TEXT', 'warehouseid': 'TEXT', 'packageid': 'TEXT'}
+packing = {'orderid': 'TEXT', 'packageid': 'TEXT', 'itemidquantitymapping': 'TEXT', 'warehouseid': 'TEXT'}
+assigncarrier = {'packageid': 'TEXT', 'warehouseid': 'TEXT', 'carrierid': 'TEXT'}
+printshippinglabel = {'packageid': 'TEXT', 'warehouseid': 'TEXT', 'carrierid': 'TEXT', 'trackingnumber': 'TEXT'}
+ship = {'packageid': 'TEXT', 'warehouseid': 'TEXT', 'carrierid': 'TEXT', 'trackingnumber': 'TEXT'}
+deliver = {'packageid': 'TEXT', 'carrierid': 'TEXT', 'trackingnumber': 'TEXT'}
+confirmdelivery = {'confirmid': 'TEXT', 'packageid': 'TEXT', 'carrierid': 'TEXT', 'trackingnumber': 'TEXT'}
+'''

--- a/eventgen_online_shopping_no_skipping_slow_start.py
+++ b/eventgen_online_shopping_no_skipping_slow_start.py
@@ -2,12 +2,13 @@ import random
 import numpy as np
 import time
 import sys
-
+import json
+import collections
 def gen_next(curr_event, id_chain):
 	event_type = curr_event["event_type_name"]
 #	if (event_type != "place_order"): print(event_type)
 	z = curr_event["event_time"]
-	next_event = {}
+	next_event = {}	
 	if event_type == "place_order":
 		next_event = {"event_type_name": "picking", 'order_id': curr_event["order_id"], 'item_id': "cast iron", 'warehouse_id': id_chain["warehouse_id"], "package_id": id_chain["package_id"], "event_time": z + np.clip((int(xmax*(0.5+np.random.normal(0,1)))),1,xmax-1)}
 		id_chain["warehouse_id"] += random.randint(1,5)
@@ -25,7 +26,7 @@ def gen_next(curr_event, id_chain):
 	elif event_type == "ship":
 		next_event = {"event_type_name": "deliver", 'package_id': curr_event["package_id"], 'carrier_id': curr_event["carrier_id"], 'tracking_number': curr_event["tracking_number"], "event_time": z + np.clip((int(mmax*(0.5+np.random.normal(0,1)))),1,mmax-1)}
 	elif event_type == "deliver":
-		next_event = {"confirm_id": 'c'+str(curr_event["package_id"]), "event_type_name": "confirm_delivery", 'package_id': curr_event["package_id"], 'carrier_id': curr_event["carrier_id"], 'tracking_number': curr_event["tracking_number"], "event_time": z+1}
+		next_event = {"event_type_name": "confirm_delivery", "confirm_id": 'c'+str(curr_event["package_id"]), 'package_id': curr_event["package_id"], 'carrier_id': curr_event["carrier_id"], 'tracking_number': curr_event["tracking_number"], "event_time": z+1}
 	else:
 		print(f"Error: {event_type} is not a continuing event for this workflow")
 	return next_event
@@ -35,20 +36,29 @@ if __name__ == '__main__':
 		batch_size, fid = int(sys.argv[1]), sys.argv[2]
 	else:
 		batch_size, fid = 100, 1
+	slow_start_batches, slow_start_ratio = 8, 0.125
 	random.seed(fid)
 	t1 = time.time()
 	# One day has 86400 seconds
 	day = 86400
+	batches = 1000
 	xmax, ymax, zmax, mmax = 5, 5, 30, 10
 	id_chain = {"order_id": 0, "package_id": 0, "warehouse_id": 0, "carrier_id": 0, "tracking_number": 0} 
-	res = [[] for y in range(100)]
+	res = [[] for y in range(batches)]
 	default_item_id_quantity_mapping = "{'cast iron': 2}"
 
-	for z in range(100):
+	for z in range(batches):
 		#If not full fill rest with place_order
+		curr_batch_size = batch_size
+		if z < slow_start_batches:
+			curr_batch_size *= slow_start_ratio
 		if len(res[z]) < batch_size:
-			for i in range(batch_size-len(res[z])):
-				place_order = {"event_type_name": "place_order", "user_id": str(i), 'order_id': str(id_chain["order_id"]), 'item_id_quantity_mapping': default_item_id_quantity_mapping, 'payment_method': 'apple pay', 'payment_amount': random.randint(90,10e5)/100,'payment_tracking_id': str(id_chain["package_id"]), "event_time": z}
+			factor = batch_size-len(res[z])
+			if z < slow_start_batches:
+				factor = min(curr_batch_size, factor)
+			factor = int(factor)
+			for i in range(factor):
+				place_order = {"event_type_name": "place_order", "user_id": str(i), 'order_id': str(id_chain["order_id"]), 'item_id_quantity_mapping': default_item_id_quantity_mapping, 'payment_method': 'apple pay', 'payment_amount': random.randint(90,10e5)/batches,'payment_tracking_id': str(id_chain["package_id"]), "event_time": z}
 				id_chain["order_id"] += random.randint(1,5)
 				res[z].append(place_order)
 		for curr_event in res[z]:
@@ -57,14 +67,14 @@ if __name__ == '__main__':
 			next_event = gen_next(curr_event, id_chain)
 			id_chain["order_id"] += random.randint(1,5)
 			next_z = next_event["event_time"]
-			if next_z < 100:
+			if next_z < batches:
 				if len(res[next_z]) < batch_size: 
 					res[next_z].append(next_event)
 
-loc = f"./sample_events_no_skipping/online_shopping_events-batch_size_{batch_size}-{fid}.txt"
+loc = f"./sample_events_no_skipping_slow_start/online_shopping_events-batch_size_{batch_size}-batches_{batches}-{fid}.txt"
 with open(loc, "a") as f:
 	batch = ""
-	for i in range(100):
+	for i in range(batches):
 		for currd in res[i]:
 			s = "{"	
 			for k,v in currd.items():
@@ -78,6 +88,16 @@ with open(loc, "a") as f:
 #sanity check for fixed batch_size
 #size_arr = [len(x) for x in res]
 #print(size_arr)
+#see event ratio within each batch
+sanitized_res = [[y["event_type_name"] for y in x] for x in res]
+freqs = []
+for sr in sanitized_res:
+	freqs.append(collections.Counter(sr))
+ratio_loc = f"./ratios/online_shopping_events-batch_size_{batch_size}-batches_{batches}-{fid}_ratios.txt"
+for freq in freqs:
+	with open(ratio_loc, "a") as f:
+		f.write(json.dumps(freq))
+		f.write('\n')
 print(f"Time taken for batch_size_{batch_size}-{fid}: {time.time() - t1}s")
 '''
 Events:

--- a/multi.py
+++ b/multi.py
@@ -1,0 +1,10 @@
+import subprocess
+import time
+if __name__ == '__main__':
+	batch_sizes = [x for x in range(100,1000,100)]
+	conf_sizes = [x for x in range(20)]
+	t1 = time.time()
+	for batch_size in batch_sizes:
+		for conf_size in conf_sizes:
+			subprocess.call(["python3.11", "./eventgen_online_shopping.py", str(batch_size), str(conf_size)])
+	print(f"Total time taken to finish - {time.time()-t1}s")

--- a/multi_icost.py
+++ b/multi_icost.py
@@ -1,0 +1,9 @@
+import subprocess
+import time
+if __name__ == '__main__':
+	batch_sizes = [10e1, 10e2, 10e3, 10e4, 10e5, 10e6]
+	t1 = time.time()
+	for batch_size in batch_sizes:
+		for fid in range(1,4):
+			subprocess.call(["python3.11", "./eventgen_icost.py", str(batch_size), str(fid)])
+	print(f"Total time taken to finish - {time.time()-t1}s")

--- a/multi_no_skipping.py
+++ b/multi_no_skipping.py
@@ -1,0 +1,9 @@
+import subprocess
+import time
+if __name__ == '__main__':
+	batch_sizes = [100, 200, 300, 500, 1000, 3000, 5000, 10000]
+	t1 = time.time()
+	for batch_size in batch_sizes:
+		for fid in range(1,4):
+			subprocess.call(["python3.11", "./eventgen_online_shopping_no_skipping.py", str(batch_size), str(fid)])
+	print(f"Total time taken to finish - {time.time()-t1}s")

--- a/ruleyacc.py
+++ b/ruleyacc.py
@@ -85,9 +85,14 @@ def p_theta(p):
 		|	LTE'''
     p[0] = p[1]
 
-def p_npair(p):
-    'npair	: 	ID pm NUMBER'
-    p[0] = (p[1], p[2], p[3])
+def p_lhs(p):
+    '''lhs	: 	ID pm ID'''
+    p[0] = {}
+    if (p[2] == '+'):
+        p[0]["coefficient_vector"] = [1,1]
+    else:
+        p[0]["coefficient_vector"] = [1,-1]
+    p[0]["variables"] = [p[1],p[3]]
 
 def p_pm(p):
     '''pm	: 	PLUS
@@ -120,11 +125,11 @@ def p_aexts(p):
         p[o].extend(p[3][:]) 
 
 def p_aext(p):
-    'aext	: 	ID theta npair'
+    'aext	: 	lhs theta NUMBER'
     p[0] = {}
-    p[0]["head_id"] = p[1]
-    p[0]["theta"] = p[2]
-    p[0]["attribute_pair"] = p[3]
+    p[0]["left_hand_side"] = p[1]
+    p[0]["comparative_operator"] = p[2]
+    p[0]["right_constant"] = p[3]
 
 def p_labels(p):
     '''labels	: 	ID COMMA labels
@@ -147,7 +152,7 @@ S1: calcsum(a1, a2; ax=SUM(x)) <-
 eva(a1, a2; x)@z IN SLIDING (s, 5),
 # Business Rule
 R1: (RentBike(Bid, Cid)@x, ReturnBike(Bid, Cid)@y) -> 
-(x <= y - 24)
+(x - y <= 24)
 '''
 result = parser.parse(s)
 print(result)

--- a/ruleyacc.py
+++ b/ruleyacc.py
@@ -27,19 +27,19 @@ def p_rule(p):
 def p_calcrule(p):
     '''calcrule	: 	ID COLON ID LPAREN labels SEMICOLON ID EQ aggf LPAREN ID RPAREN RPAREN BA ID LPAREN labels SEMICOLON ID RPAREN AT ID IN wtype LPAREN ID COMMA NUMBER RPAREN wm'''
     p[0] = {}
-    p[0]["id"] = p[1] 
-    p[0]["iname"] = p[3]
-    p[0]["labels"] = p[5]
-    p[0]["amn"] = p[7]
-    p[0]["aggf"] = p[9]
-    p[0]["mname"] = p[11]
-    p[0]["name"] = p[15]
-    p[0]["labels2"] = p[17]
-    p[0]["mname2"] = p[19]
-    p[0]["wtype"] = p[24]
-    p[0]["wend"] = p[26]
-    p[0]["wlen"] = p[28]
-    p[0]["wmod"] = p[30]
+    p[0]["rule_id"] = p[1] 
+    p[0]["internal_event_type_name"] = p[3]
+    p[0]["head_labels"] = p[5]
+    p[0]["aggregated_metric_name"] = p[7]
+    p[0]["aggregation_function"] = p[9]
+    p[0]["metric_name"] = p[11]
+    p[0]["body_function"] = p[15]
+    p[0]["body_labels"] = p[17]
+    p[0]["body_name"] = p[19]
+    p[0]["window_type"] = p[24]
+    p[0]["window_end"] = p[26]
+    p[0]["window_length"] = p[28]
+    p[0]["window_modulus"] = p[30]
 
 def p_aggf(p):
     '''aggf	: 	SUM
@@ -61,16 +61,16 @@ def p_wm(p):
 		| 	empty'''
     p[0] = {}
     if len(p) > 2:
-        p[0]["wtype"] = p[1]
-        p[0]["wend"] = p[3]
-        p[0]["wlen"] = p[5]
+        p[0]["window_type"] = p[1]
+        p[0]["window_end"] = p[3]
+        p[0]["window_length"] = p[5]
 
 def p_brule(p):
     'brule		: 	ID COLON LPAREN iexts RPAREN FA LPAREN aexts RPAREN'
     p[0] = {}
     p[0]["id"] = p[1]
-    p[0]["iexts"] = p[4]
-    p[0]["aexts"] = p[8]
+    p[0]["body"] = p[4]
+    p[0]["head"] = p[8]
 
 def p_iid(p):
     '''iid	: 	INTERNAL
@@ -106,7 +106,7 @@ def p_iext(p):
     'iext	: 	iid ID LPAREN labels RPAREN AT ID' 
     p[0] = {}
     if len(p) > 2:
-        p[0]["iid"] = p[1]
+        p[0]["body_id"] = p[1]
         p[0]["name"] = p[2]
         p[0]["labels"] = p[4]
         p[0]["zid"] = p[7]
@@ -122,9 +122,9 @@ def p_aexts(p):
 def p_aext(p):
     'aext	: 	ID theta npair'
     p[0] = {}
-    p[0]["id"] = p[1]
+    p[0]["head_id"] = p[1]
     p[0]["theta"] = p[2]
-    p[0]["npair"] = p[3]
+    p[0]["attribute_pair"] = p[3]
 
 def p_labels(p):
     '''labels	: 	ID COMMA labels

--- a/ruleyacc.py
+++ b/ruleyacc.py
@@ -57,13 +57,11 @@ def p_wtype(p):
     p[0] = p[1]
 
 def p_wm(p):
-    '''wm	: 	ID MOD NUMBER EQ NUMBER
-		| 	empty'''
+    '''wm	: 	ID MOD NUMBER EQ NUMBER'''
     p[0] = {}
-    if len(p) > 2:
-        p[0]["window_type"] = p[1]
-        p[0]["window_end"] = p[3]
-        p[0]["window_length"] = p[5]
+    p[0]["window_type"] = p[1]
+    p[0]["window_end"] = p[3]
+    p[0]["window_length"] = p[5]
 
 def p_brule(p):
     'brule		: 	ID COLON LPAREN iexts RPAREN FA LPAREN aexts RPAREN'


### PR DESCRIPTION
# Items revised
## Output keys
- Use full names instead of acronyms

## Output for ArithmeticAtom
- Shaped with vectors per request

## Demonstration with business rule output
<img width="1440" alt="Screenshot 2024-10-29 at 9 23 57 PM" src="https://github.com/user-attachments/assets/116dd1ce-47b7-4b45-9b91-025016c96225">

## Command-line change for event generation
Adds in command-line arguments for batch_size and ratio control
example: `python3.11 eventgen_online_shopping.py 100 1` uses batch_size=100 and number of confirm_delivery events per order = 1

## Multi-file generation
See files prefixed with _multi_ and change for range of batch sizes
example: `python3.11 multi_icost.py`